### PR TITLE
Fix variables

### DIFF
--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -73,5 +73,7 @@ class Parser(object):
             tokens_checked += 1
         
         self.varObj.set_variable(name, operator, value)
+        print("-- ENVIRONMENT --")
+        print(self.varObj.variables)
 
         self.token_index += tokens_checked

--- a/src/lexer.py
+++ b/src/lexer.py
@@ -5,22 +5,17 @@ class Lexer(object):
     
     def __init__(self, source_code):
         self.source_code = source_code
-        self.varObj = varObject.VariableObject()
-
+    
     def tokenize(self):
-        vars = self.varObj
         tokens = []
         source_code = self.source_code.split()
         source_index = 0
-        print(vars.variables)
 
         while source_index < len(source_code):
             word = source_code[source_index]
 
             if word == "var":
                 tokens.append(["VAR_DECLARATION", word])
-            elif word in self.varObj.variables:
-                print("VARIABLE")
             elif word == "print":
                 tokens.append(["PRINT_STATEMENT", word])
             elif re.match("[a-z]", word) or re.match("[A-Z]", word) or word[0] in ["\"", "\'"]:


### PR DESCRIPTION
# Fix variables
## What I have Changed
I've fixed the dictionary issue with variables. There was dead code in the lexer that was creating the illusion of the variable object being printed, however it was an unused variable object that never actually had anything assigned to it. Now, when you run:
```
var x = 8
```
you get the output:
```
-- ENVIRONMENT --
{'x': '8'}
```

## Reference an Issue
#7 
