### PR TITLE
Fix typos and mistakes in Contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,16 @@
 # Contibuting #
 ## We thank you for taking the time to read these guidelines ##
-The project and people in this project are governed by Our Code of Conduct. Please report any abusive behaviour [here](https://github.com/Solar-language/Solar/issues/3).
+The project and people in this project are governed by Our Code of Conduct. Please report any abusive behaviour [here](https://github.com/N-language/N-/issues/3).
 
 ### Questions ###
-Feel free to ask question in the [Questions Issue](https://github.com/Solar-language/Solar/issues/4).
+Feel free to ask question in the [Questions Issue](https://github.com/N-language/N-/issues/4).
 
 ### Ways I can Contribute ###
 There are a few different ways of helping in N#.
 #### Requesting Features ####
-If you find a bug in Solar, then open an issue using the **Bug Report** Template and give as much information as you can.
+If you find a bug in N#, then open an issue using the **Bug Report** Template and give as much information as you can.
 #### Reporting Bugs ####
-If you want something new to come in the next version of Solar, open an issue using the **Feature request** template. Remeber, your suggestion might not become part of N#.
+If you want something new to come in the next version of N#, open an issue using the **Feature request** template. Remember, your suggestion might not become part of N#.
 #### Writing Code ####
 If you know Python and want to help, then feel free to create a pull request, again though, your code may or may not be used in N#.
 


### PR DESCRIPTION
# Fix typos and mistakes in Contributing.md
## What I have Changed
I have fixed the links that lined to Solar and replaced them with the correct n# links, as well as pick up a few typos.

@BonfireScratch 
